### PR TITLE
Update official seiscomp web page URL

### DIFF
--- a/docs/software.rst
+++ b/docs/software.rst
@@ -11,7 +11,7 @@ the SeedLink protocol.
 SeisComP
 --------
 
-https://www.seiscomp3.org/
+https://www.seiscomp.de/
 
 slinktool
 ---------


### PR DESCRIPTION
I have the doubt that the former URL was left intentionally there, but I'll propose the change anyway and let you decide what is best